### PR TITLE
Few bug fixes and enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ and you should whether the connexion is OK or not
 Modify the settings in 
 `/script/hb/HeaderBiddingCreation.php`
 * SSP must be an array of ssp you want to create - please enter here the bidder code defined in prebid documentation
-* Price Granularity are standards, defined on [prebid.org](http://prebid.org/prebid-mobile/adops-price-granularity.html).
+* Price Granularity are standards, defined on [prebid.org](http://prebid.org/prebid-mobile/adops-price-granularity.html). You can also define a custom granularity by passing an array of buckets in the format `[ [$start_value, $end_value, $increment] ]`.
 * Currency is the AdServer Currency (USD, EUR...)
 * Sizes: please enter all sizes allowed on your inventory 
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,16 @@ and you should whether the connexion is OK or not
 Modify the settings in 
 `/script/hb/HeaderBiddingCreation.php`
 * SSP must be an array of ssp you want to create - please enter here the bidder code defined in prebid documentation
-* Price Granularity are standards, defined on [prebid.org](http://prebid.org/prebid-mobile/adops-price-granularity.html). You can also define a custom granularity by passing an array of buckets in the format `[ [$start_value, $end_value, $increment] ]`.
+* Price Granularity are standards, defined on [prebid.org](http://prebid.org/prebid-mobile/adops-price-granularity.html). You can also define a custom granularity by passing an array of buckets in the format 
+    ```
+        'priceGranularity' => [ 
+            'buckets' => [
+                ['precision' => 2, 'min' => 0, 'max' => 5, 'increment' => 0.05],
+                ['precision' => 2, 'min' => 5, 'max' => 10, 'increment' => 0.1],
+                ['precision' => 2, 'min' => 10, 'max' => 20, 'increment' => 0.5],
+            ]
+        ]
+    ```
 * Currency is the AdServer Currency (USD, EUR...)
 * Sizes: please enter all sizes allowed on your inventory 
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ and you should whether the connexion is OK or not
 Modify the settings in 
 `/script/hb/HeaderBiddingCreation.php`
 * SSP must be an array of ssp you want to create - please enter here the bidder code defined in prebid documentation
-* Price Granularity are standards, defined on [prebid.org](http://prebid.org/prebid-mobile/adops-price-granularity.html). You can also define a custom granularity by passing an array of buckets in the format 
+* Price Granularity are standards, defined on [prebid.org](http://prebid.org/prebid-mobile/adops-price-granularity.html). You can also define a custom granularity by passing an array of buckets in the following format 
+    
     ```
         'priceGranularity' => [ 
             'buckets' => [
-                ['precision' => 2, 'min' => 0, 'max' => 5, 'increment' => 0.05],
-                ['precision' => 2, 'min' => 5, 'max' => 10, 'increment' => 0.1],
-                ['precision' => 2, 'min' => 10, 'max' => 20, 'increment' => 0.5],
+                ['min' => 0, 'max' => 5, 'increment' => 0.05, 'precision' => 2 /* optional */],
+                ['min' => 5, 'max' => 10, 'increment' => 0.1, 'precision' => 2 /* optional */],
+                ['min' => 10, 'max' => 20, 'increment' => 0.5, 'precision' => 2 /* optional */],
             ]
         ]
     ```

--- a/app/Dfp/CreativeManager.php
+++ b/app/Dfp/CreativeManager.php
@@ -74,8 +74,6 @@ class CreativeManager extends DfpManager
 				return $output;
 			}
 			foreach ($data->getResults() as $creative) {
-			    var_dump($creative);
-			    exit;
 			    $foo = array(
 			  		"creativeId" => $creative->getId(),
 			        "creativeName" => $creative->getName(),
@@ -95,8 +93,9 @@ class CreativeManager extends DfpManager
 		$creativeService = $this->dfpServices->get($this->session, CreativeService::class);
 		$statementBuilder = (new StatementBuilder())
 			->orderBy('id ASC')
-			->where('name = :name')
-			->WithBindVariableValue('name', $creativeName);
+			->where('name = :name AND advertiserId = :advertiserId')
+			->WithBindVariableValue('name', $creativeName)
+			->WithBindVariableValue('advertiserId', $this->advertiserId);
 		$data = $creativeService->getCreativesByStatement($statementBuilder->toStatement());
 		if ($data->getResults() !== null)
 		{

--- a/app/Dfp/LineItemManager.php
+++ b/app/Dfp/LineItemManager.php
@@ -140,8 +140,9 @@ class LineItemManager extends DfpManager
         $lineItemService = $this->dfpServices->get($this->session, LineItemService::class);
         $statementBuilder = (new StatementBuilder())
             ->orderBy('id ASC')
-            ->where('name = :name')
-            ->WithBindVariableValue('name', $this->lineItemName);
+            ->where('name = :name AND orderId = :orderId')
+            ->WithBindVariableValue('name', $this->lineItemName)
+            ->WithBindVariableValue('orderId', $this->orderId);
         $data = $lineItemService->getLineItemsByStatement($statementBuilder->toStatement());
         if ($data->getResults() !== null)
         {

--- a/app/Dfp/ValueManager.php
+++ b/app/Dfp/ValueManager.php
@@ -121,6 +121,7 @@ class ValueManager extends DfpManager
 			$data = $customTargetingService->getCustomTargetingValuesByStatement($statementBuilder->toStatement());
 			if ($data->getResults() !== null)
 			{
+				$totalResultSetSize = $data->getTotalResultSetSize();
 				foreach ($data->getResults() as $value) {
 				    $foo = array(
 				  		"valueId" => $value->getId(),
@@ -128,8 +129,8 @@ class ValueManager extends DfpManager
 				        "valueDisplayName" => $value->getDisplayName()
 				    );
 				    array_push($output, $foo);
-				    $statementBuilder->increaseOffsetBy($pageSize);
 				}
+			    $statementBuilder->increaseOffsetBy($pageSize);
 			}
 		} while ($statementBuilder->getOffset() < $totalResultSetSize);
 		return $output;

--- a/app/Dfp/ValueManager.php
+++ b/app/Dfp/ValueManager.php
@@ -35,13 +35,17 @@ class ValueManager extends DfpManager
 	public function convertValuesListToDFPValuesList($valuesList)
 	{
 		//We get from DFP which keys already exists
-		$output = $this->getExistingValuesFromDFP();
+		$existing = $this->getExistingValuesFromDFP();
 
 		//We create a table with only existing keys
 		$existingValuesList = [];
+		$output = [];
 		
-		foreach ($output as $foo) {
+		foreach ($existing as $foo) {
 			array_push($existingValuesList, $foo['valueName']);
+			if (in_array($foo['valueName'], $valuesList)) {
+				array_push($output, $foo);
+			}
 		}
 
 		//We create a list with values to be created

--- a/app/Scripts/Buckets.php
+++ b/app/Scripts/Buckets.php
@@ -8,26 +8,26 @@ class Buckets
 	{
 		$predefinedGranularityBuckets = [
 			'low' => [
-				[0, 5, 0.5]
+				['precision' => 2, 'min' => 0, 'max' => 5, 'increment' => 0.5]
 			],
 			'med' => [
-				[0, 20, 0.1]
+				['precision' => 2, 'min' => 0, 'max' => 20, 'increment' => 0.1]
 			],
 			'high' => [
-				[0, 20, 0.01]
+				['precision' => 2, 'min' => 0, 'max' => 20, 'increment' => 0.01]
 			],
 			'auto' => [
-				[0, 5, 0.05],
-				[5, 10, 0.1],
-				[10, 20, 0.5],
+				['precision' => 2, 'min' => 0, 'max' => 5, 'increment' => 0.05],
+				['precision' => 2, 'min' => 5, 'max' => 10, 'increment' => 0.1],
+				['precision' => 2, 'min' => 10, 'max' => 20, 'increment' => 0.5],
 			],
 			'dense' => [
-				[0, 3, 0.01],
-				[3, 8, 0.05],
-				[8, 20, 0.5],
+				['precision' => 2, 'min' => 0, 'max' => 3, 'increment' => 0.01],
+				['precision' => 2, 'min' => 3, 'max' => 8, 'increment' => 0.05],
+				['precision' => 2, 'min' => 8, 'max' => 20, 'increment' => 0.5],
 			],
 			'test' => [
-				[0, 20, 2.5]
+				['precision' => 2, 'min' => 0, 'max' => 20, 'increment' => 2.5]
 			]
 		];
 		
@@ -42,9 +42,11 @@ class Buckets
 				echo "Error: You need to choose an value in 'low', 'med', 'high', 'auto','dense'!!!\n";
 				exit;
 			}
+		} else {
+			$value = $value["buckets"];
 		}
 		
-		if (!is_array($value[0])) {
+		if (!isset($value[0]['increment'])) {
 			echo "Error: custom granularity should specify an array of buckets\n";
 			exit;
 		}
@@ -60,11 +62,11 @@ class Buckets
 		{
 			// Floating point comparison is not reliable
 			// https://stackoverflow.com/questions/3148937/compare-floats-in-php
-			for($i = $value[0]; bccomp($i, $value[1], 2) <= 0; $i += $value[2])
+			for($i = $value['min']; bccomp($i, $value['max'], 2) <= 0; $i += $value['increment'])
 			{
 				if ($i > 0 && bccomp($i, $lastValue, 2) !== 0)
 				{
-					array_push($buckets, sprintf('%0.2f', $i));
+					array_push($buckets, sprintf("%0.{$value['precision']}f", $i));
 				}
 				$lastValue = $i;
 			}

--- a/app/Scripts/Buckets.php
+++ b/app/Scripts/Buckets.php
@@ -60,13 +60,14 @@ class Buckets
 		$lastValue = 0;
 		foreach ($priceGranularity as $value)
 		{
+			$precision = isset($value['precision']) ? $value['precision'] : 2;
 			// Floating point comparison is not reliable
 			// https://stackoverflow.com/questions/3148937/compare-floats-in-php
-			for($i = $value['min']; bccomp($i, $value['max'], 2) <= 0; $i += $value['increment'])
+			for($i = $value['min']; bccomp($i, $value['max'], $precision) <= 0; $i += $value['increment'])
 			{
 				if ($i > 0 && bccomp($i, $lastValue, 2) !== 0)
 				{
-					array_push($buckets, sprintf("%0.{$value['precision']}f", $i));
+					array_push($buckets, sprintf("%0.{$precision}f", $i));
 				}
 				$lastValue = $i;
 			}

--- a/app/Scripts/Buckets.php
+++ b/app/Scripts/Buckets.php
@@ -44,6 +44,11 @@ class Buckets
 			}
 		}
 		
+		if (!is_array($value[0])) {
+			echo "Error: custom granularity should specify an array of buckets\n";
+			exit;
+		}
+		
 		return self::create($value);
 	}
 	

--- a/app/Scripts/Buckets.php
+++ b/app/Scripts/Buckets.php
@@ -6,104 +6,65 @@ class Buckets
 {
 	public static function createBuckets($value)
 	{
-		if(in_array($value, ['low', 'med', 'high', 'auto','dense', 'test']))
+		$predefinedGranularityBuckets = [
+			'low' => [
+				[0, 5, 0.5]
+			],
+			'med' => [
+				[0, 20, 0.1]
+			],
+			'high' => [
+				[0, 20, 0.01]
+			],
+			'auto' => [
+				[0, 5, 0.05],
+				[5, 10, 0.1],
+				[10, 20, 0.5],
+			],
+			'dense' => [
+				[0, 3, 0.01],
+				[3, 8, 0.05],
+				[8, 20, 0.5],
+			],
+			'test' => [
+				[0, 20, 2.5]
+			]
+		];
+		
+		if (is_string($value))
 		{
-			$function = "create".ucfirst($value)."Buckets";
-			return self::$function();
+			if (isset($predefinedGranularityBuckets[$value])) 
+			{
+				$value = $predefinedGranularityBuckets[$value];
+			}
+			else
+			{
+				echo "Error: You need to choose an value in 'low', 'med', 'high', 'auto','dense'!!!\n";
+				exit;
+			}
 		}
-		else
-		{
-			echo "Error: You need to choose an value in 'low', 'med', 'high', 'auto','dense'!!!\n";
-			exit;
-		}
-		/*
-		switch ($values) {
-			case "dense":
-				return self::createDenseBuckets();
-			case "low":
-				return self::createLowBuckets();	
-			case "test":
-				return self::createTestBuckets();
-			default:
-				return [];
-		}
-		*/
+		
+		return self::create($value);
 	}
-
-	private function createDenseBuckets()
+	
+	private static function create($priceGranularity)
 	{
 		$buckets = [];
-		for($i = 0;$i <= 3; $i = $i + 0.01)
+		$lastValue = 0;
+		foreach ($priceGranularity as $value)
 		{
-			array_push($buckets, sprintf('%0.2f', $i));
+			// Floating point comparison is not reliable
+			// https://stackoverflow.com/questions/3148937/compare-floats-in-php
+			for($i = $value[0]; bccomp($i, $value[1], 2) <= 0; $i += $value[2])
+			{
+				if ($i > 0 && bccomp($i, $lastValue, 2) !== 0)
+				{
+					array_push($buckets, sprintf('%0.2f', $i));
+				}
+				$lastValue = $i;
+			}
 		}
-		for($i = 3.05;$i <= 8; $i = $i + 0.05)
-		{
-			array_push($buckets, sprintf('%0.2f', $i));
-		}
-		for($i = 8.5;$i <= 20; $i = $i + 0.5)
-		{
-			array_push($buckets, sprintf('%0.2f', $i));
-		}
+		
 		return $buckets;
 	}
-
-	private function createAutoBuckets()
-	{
-		$buckets = [];
-		for($i = 0;$i <= 5; $i = $i + 0.05)
-		{
-			array_push($buckets, sprintf('%0.2f', $i));
-		}
-		for($i = 5.1 ;$i <= 10; $i = $i + 0.1)
-		{
-			array_push($buckets, sprintf('%0.2f', $i));
-		}
-		for($i = 10.5;$i <= 20; $i = $i + 0.5)
-		{
-			array_push($buckets, sprintf('%0.2f', $i));
-		}
-		return $buckets;
-	}
-
-	private function createLowBuckets()
-	{
-		$buckets = [];
-		for($i = 0;$i <= 5; $i = $i + 0.5)
-		{
-			array_push($buckets, sprintf('%0.2f', $i));
-		}
-		return $buckets;
-	}
-
-	private function createMedBuckets()
-	{
-		$buckets = [];
-		for($i = 0;$i <= 20; $i = $i + 0.1)
-		{
-			array_push($buckets, sprintf('%0.2f', $i));
-		}
-		return $buckets;
-	}
-
-	private function createHighBuckets()
-	{
-		$buckets = [];
-		for($i = 0;$i <= 20; $i = $i + 0.01)
-		{
-			array_push($buckets, sprintf('%0.2f', $i));
-		}
-		return $buckets;
-	}
-
-	private function createTestBuckets()
-	{
-		$buckets = [];
-		for($i = 0;$i <= 20; $i = $i + 2.5)
-		{
-			array_push($buckets, sprintf('%0.2f', $i));
-		}
-		return $buckets;
-	}
-
 }

--- a/app/Scripts/HeaderBiddingScript.php
+++ b/app/Scripts/HeaderBiddingScript.php
@@ -14,7 +14,7 @@ class HeaderBiddingScript
 	{
 		foreach($params['ssp'] as $ssp)
 		{
-			$params = array(
+			$param = array(
 				"orderName" => "Insideall - Prebid - ".ucfirst($ssp),
 				"advertiserName" => "Insideall - Prebid - ".ucfirst($ssp),
 				"priceGranularity" => $params["priceGranularity"],
@@ -25,7 +25,7 @@ class HeaderBiddingScript
 				"currency"=>$params['currency'],
 				"ssp"=>$ssp
 			);
-			$script = new SSPScript($params);
+			$script = new SSPScript($param);
 
 			$script->createAdUnits();
 		}


### PR DESCRIPTION
I have fixed a few bugs and added option to specify custom price granularity. Sorry about the single pull request for multiple changes.

*Bugs*

- Comparison of floating point numbers was not working as expected when generating value buckets. I am not sure whether this has something to do with my PHP installation. But it appears there are other people who have faced [similar issues](https://stackoverflow.com/questions/3148937/compare-floats-in-php))
- `$param` was being overwritten within for loop in `HeaderBiddingScript`
- Paging through key-value pairs was not working correctly when there are more than `SUGGESTED_PAGE_LIMIT` entries.
- Updated check to prevent the script from attempting to re-create existing key-value pairs (Should fix https://github.com/Insideall/dfp-prebid-lineitems/issues/1 )

*Enhancements*
- Added support for custom price granularity