### PR TITLE
Activate existing key-values

### DIFF
--- a/app/AdManager/CreativeManager.php
+++ b/app/AdManager/CreativeManager.php
@@ -5,7 +5,6 @@ namespace App\AdManager;
 require __DIR__.'/../../vendor/autoload.php';
 
 use Google\AdsApi\AdManager\Util\v201811\StatementBuilder;
-use Google\AdsApi\AdManager\v201811\CreativeService;
 use Google\AdsApi\AdManager\v201811\ThirdPartyCreative;
 use Google\AdsApi\AdManager\v201811\Size;
 

--- a/app/AdManager/KeyManager.php
+++ b/app/AdManager/KeyManager.php
@@ -8,7 +8,6 @@ use Google\AdsApi\AdManager\v201811\CustomTargetingKey;
 use Google\AdsApi\AdManager\v201811\CustomTargetingKeyType;
 use Google\AdsApi\AdManager\Util\v201811\StatementBuilder;
 
-
 class KeyManager extends Manager
 {
 	public function setUpCustomTargetingKey($keyName)

--- a/app/AdManager/KeyManager.php
+++ b/app/AdManager/KeyManager.php
@@ -4,6 +4,7 @@ namespace App\AdManager;
 
 require __DIR__.'/../../vendor/autoload.php';
 
+use Google\AdsApi\AdManager\v201811\ActivateCustomTargetingKeys;
 use Google\AdsApi\AdManager\v201811\CustomTargetingKey;
 use Google\AdsApi\AdManager\v201811\CustomTargetingKeyType;
 use Google\AdsApi\AdManager\Util\v201811\StatementBuilder;
@@ -14,6 +15,8 @@ class KeyManager extends Manager
 	{
 		if (empty(($foo = $this->getCustomTargetingKey($keyName)))) {
 			$foo = $this->createCustomTargetingKey($keyName);
+		} elseif ($foo[0]['keyStatus'] === 'INACTIVE') {
+			$this->activateCustomTargetingKey($keyName);
 		}
 
 		return $foo[0]['keyId'];
@@ -33,6 +36,7 @@ class KeyManager extends Manager
 			$foo = [
 				'keyId' => $key->getId(),
 				'keyName' => $key->getName(),
+				'keyStatus' => $key->getStatus(),
 				'keyDisplayNameId' => $key->getDisplayName(),
 			];
 			array_push($output, $foo);
@@ -54,12 +58,25 @@ class KeyManager extends Manager
 			$foo = [
 				'keyId' => $key->getId(),
 				'keyName' => $key->getName(),
+				'keyStatus' => $key->getStatus(),
 				'keyDisplayNameId' => $key->getDisplayName(),
 			];
 			array_push($output, $foo);
 		}
 
 		return $output;
+	}
+
+	public function activateCustomTargetingKey($keyName)
+	{
+		$action = new ActivateCustomTargetingKeys();
+
+		$statementBuilder = (new StatementBuilder())
+			->where('name = :name')
+			->WithBindVariableValue('name', $keyName);
+
+		$customTargetingService = $this->serviceFactory->createCustomTargetingService($this->session);
+		$result = $customTargetingService->performCustomTargetingKeyAction($action, $statementBuilder->toStatement());
 	}
 
 	public function getCustomTargetingKey($keyName)
@@ -76,6 +93,7 @@ class KeyManager extends Manager
 				$foo = [
 					'keyId' => $key->getId(),
 					'keyName' => $key->getName(),
+					'keyStatus' => $key->getStatus(),
 					'keyDisplayNameId' => $key->getDisplayName(),
 				];
 				array_push($output, $foo);

--- a/app/AdManager/LineItemCreativeAssociationManager.php
+++ b/app/AdManager/LineItemCreativeAssociationManager.php
@@ -5,7 +5,6 @@ namespace App\AdManager;
 require __DIR__.'/../../vendor/autoload.php';
 
 use Google\AdsApi\AdManager\v201811\LineItemCreativeAssociation;
-use Google\AdsApi\AdManager\v201811\LineItemCreativeAssociationService;
 use Google\AdsApi\AdManager\v201811\Size;
 use Google\AdsApi\AdManager\Util\v201811\StatementBuilder;
 use Google\AdsApi\AdManager\v201811\ApiException;

--- a/app/AdManager/Manager.php
+++ b/app/AdManager/Manager.php
@@ -4,11 +4,10 @@ namespace App\AdManager;
 
 require __DIR__.'/../../vendor/autoload.php';
 
-use Google\AdsApi\AdManager\AdManagerSession;
 use Google\AdsApi\AdManager\AdManagerSessionBuilder;
 use Google\AdsApi\Common\OAuth2TokenBuilder;
-
 use Google\AdsApi\AdManager\v201811\ServiceFactory;
+
 class Manager
 {
 	protected $serviceFactory;

--- a/app/AdManager/NetworkManager.php
+++ b/app/AdManager/NetworkManager.php
@@ -4,8 +4,6 @@ namespace App\AdManager;
 
 require __DIR__.'/../../vendor/autoload.php';
 
-use Google\AdsApi\AdManager\v201811\NetworkService;
-
 class NetworkManager extends Manager
 {
 	protected $dfpServices;

--- a/app/AdManager/RootAdUnitManager.php
+++ b/app/AdManager/RootAdUnitManager.php
@@ -4,8 +4,6 @@ namespace App\AdManager;
 
 require __DIR__.'/../../vendor/autoload.php';
 
-use Google\AdsApi\AdManager\v201811\NetworkService;
-
 class RootAdUnitManager extends Manager
 {
 	public function setRootAdUnit()

--- a/app/Scripts/HeaderBiddingScript.php
+++ b/app/Scripts/HeaderBiddingScript.php
@@ -21,6 +21,7 @@ class HeaderBiddingScript
 				'adidKeyName' => substr("hb_adid_$ssp", 0, 20),
 				'sizeKeyName' => substr("hb_size_$ssp", 0, 20),
 				'currency' => $params['currency'],
+				'trafficker' => isset($params['trafficker']) ? $params['trafficker'] : null,
 				'ssp' => $ssp,
 			];
 			$script = new SSPScript($param);
@@ -40,6 +41,7 @@ class HeaderBiddingScript
 			'adidKeyName' => substr('hb_adid', 0, 20),
 			'sizeKeyName' => substr('hb_size', 0, 20),
 			'currency' => $params['currency'],
+			'trafficker' => isset($params['trafficker']) ? $params['trafficker'] : null,
 			'ssp' => '',
 		];
 		$script = new SSPScript($params);

--- a/app/Scripts/SSPScript.php
+++ b/app/Scripts/SSPScript.php
@@ -38,10 +38,8 @@ class SSPScript extends \App\AdManager\Manager
 		$this->valuesList = Buckets::createBuckets($this->priceGranularity);
 
 		//Get the Trafficker Id
-		$this->traffickerId = (new \App\AdManager\UserManager())->getUserId();
+		$this->traffickerId = (new \App\AdManager\UserManager($this->trafficker))->getUserId();
 		echo 'TraffickerId: '.$this->traffickerId."\n";
-
-		
 
 		//Get the Advertising Company Id
 		$this->advertiserId = (new \App\AdManager\CompanyManager())->setUpCompany($this->advertiserName);
@@ -50,7 +48,6 @@ class SSPScript extends \App\AdManager\Manager
 		//Get the OrderId
 		$this->orderId = (new \App\AdManager\OrderManager())->setUpOrder($this->orderName, $this->advertiserId, $this->traffickerId);
 		echo 'OrderName : '.$this->orderName."\tOrderId: ".$this->orderId."\n";
-
 
 		//Create and get KeyIds
 		$this->priceKeyId = (new \App\AdManager\KeyManager())->setUpCustomTargetingKey($this->priceKeyName);
@@ -66,14 +63,10 @@ class SSPScript extends \App\AdManager\Manager
 		$this->dfpValuesList = $valuesManager->convertValuesListToDFPValuesList($this->valuesList);
 		echo "Values List Created\n";
 
-
-
-
 		$creativeManager = new \App\AdManager\CreativeManager();
 		$creativeManager->setSsp($this->ssp)
 			->setAdvertiserId($this->advertiserId);
 		$this->creativesList = $creativeManager->setUpCreatives();
-
 
 		echo "\n\n".json_encode($this->creativesList)."\n\n";
 		$this->rootAdUnitId = (new \App\AdManager\RootAdUnitManager())->setRootAdUnit();


### PR DESCRIPTION
Automatically activate existing key values pairs that are disabled.

When I disabled an adapter, I manually de-activated the associated Key-Values. Running the script again skipped creating the key values, and AdManager interface does not show deactivated Keys.

This PR will detect de-activated key-values and activate them.